### PR TITLE
Korrekturen Wording

### DIFF
--- a/config/locales/models.cevi.de.yml
+++ b/config/locales/models.cevi.de.yml
@@ -11,8 +11,8 @@ de:
   activerecord:
     models:
       event/application:
-        one: Voranmeldung
-        other: Voranmeldungen
+        one: Anmeldung
+        other: Anmeldungen
       group/dachverband:
         one: Dachverband
         other: Dachverbände
@@ -803,7 +803,7 @@ de:
         finish_at: Stichdatum
 
       event:
-        waiting_list: Voranmeldungen
+        waiting_list: Automatisch zugeteilt
         application_contact: Anmeldung an
         application_contact_id: Anmeldung an
 

--- a/config/locales/views.cevi.de.yml
+++ b/config/locales/views.cevi.de.yml
@@ -51,7 +51,7 @@ de:
 
   events:
     form:
-      caption_waiting_list: Teilnehmende können sich selbst immer nur voranmelden und müssen dann manuell zugewiesen werden, auch wenn es noch freie Plätze hat.
+      caption_waiting_list: Wenn es noch freie Plätze hat, werden Teilnehmende automatisch zugeteilt.
       caption_requires_approval: 'Der Coach wird informiert und muss die Anmeldung bestätigen'
 
   member_counts:


### PR DESCRIPTION
Ich habe das eben getestet und der Effekt der Checkbox scheint genau umgekehrt zum alten Wording, habe deshalb ein neues vorgeschlagen. (Ich hoffe, ich habe das richtige Label `waiting_list` label gefunden ;-)

Die Anpassung von Anmeldung auf Voranmeldung hat an einigen Orten geholfen, an ein paar wichtigen aber für  Verwirrung gesorgt. Screenshots:
  * Das Rot markierte Voranmeldung sehen die TN (beim grünen ist auch "Anmeldung" verständlich.)
![übersicht](https://user-images.githubusercontent.com/1123483/209584565-90312da0-2db2-4253-bdfe-e1447764e593.png)
  * Rot ist verwirrend, Grün wird mit dem Pull-Request sowieso geändert
![config](https://user-images.githubusercontent.com/1123483/209584560-531eea91-dcae-467e-8be4-b30a2e65dd26.png)
  * Hier ist auch Anmeldung völlig ok.
![tab_voranmeldungen](https://user-images.githubusercontent.com/1123483/209584562-2d040703-709f-4ed2-8951-dd17eb40a2b7.png)
  * Hier wäre Voranmeldung besser, der negative Effekt insbesondere auf der Kurs-Hauptseite ist aber grösser. Mit dem  neuen Mail wird der Unterschied von Anmeldungen und Teilnahmen hoffentlich klarer.
![tn_profil](https://user-images.githubusercontent.com/1123483/209584564-7dfeb6aa-c2fc-4acd-98e0-70b142f4d9a0.png)
  * Wenn ich das richtig gesehen habe, ist das ein anderes Textelement und bleibt unverändert. 
![tn_anmeldung](https://user-images.githubusercontent.com/1123483/209584563-708dceda-b596-4165-b5b2-efef6bb12a50.png)



