### PR TITLE
automatically cleanup participations (6 months)

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,3 +51,8 @@ csv:
 groups:
   statistics:
     enabled: false
+
+event:
+  participations:
+    delete_additional_information_after_months: 6
+    delete_answers_after_months: 6


### PR DESCRIPTION
Wir wollen Antworten in unseren Events ebenfalls löschen.
Aktuell setzen wir die Frist auf 6 Monate, wenn alles klappt können wir die in Zukunft problemlos auf 3 Monate reduzieren.