### PR TITLE
Remove AktiverKursleiter role from DachverbandGremium

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -18,7 +18,6 @@ This hitobito wagon defines the organization hierarchy with groups and roles of 
       * Gremium
         * Leitung: [:layer_read, :group_and_below_full, :contact_data]
         * Mitglied: [:layer_read, :group_and_below_full]
-        * Aktive/-r Kursleiter/-in: [:layer_read, :group_and_below_full]
         * Kassier: [:layer_read, :group_and_below_full, :finance]
       * Mitglieder
         * Adressverwalter/-in: [:group_and_below_full]

--- a/app/models/group/dachverband_gremium.rb
+++ b/app/models/group/dachverband_gremium.rb
@@ -20,12 +20,6 @@ class Group::DachverbandGremium < Group::Gremium
   end
 
   # get the group_and_below_full permission as they should also be able to create events
-  class AktiverKursleiter < ::Role
-    self.permissions = [:layer_read, :group_and_below_full]
-    self.two_factor_authentication_enforced = true
-  end
-
-  # get the group_and_below_full permission as they should also be able to create events
   class Kassier < ::Role
     self.permissions = [:layer_read, :group_and_below_full, :finance]
     self.two_factor_authentication_enforced = true
@@ -33,6 +27,5 @@ class Group::DachverbandGremium < Group::Gremium
 
   roles Leitung,
     Mitglied,
-    AktiverKursleiter,
     Kassier
 end

--- a/db/migrate/20260314000000_remove_aktiver_kursleiter_from_dachverband_gremium.rb
+++ b/db/migrate/20260314000000_remove_aktiver_kursleiter_from_dachverband_gremium.rb
@@ -4,9 +4,76 @@
 #  https://github.com/hitobito/hitobito_cevi.
 
 class RemoveAktiverKursleiterFromDachverbandGremium < ActiveRecord::Migration[6.1]
+  OLD_TYPE = 'Group::DachverbandGremium::AktiverKursleiter'
+  NEW_TYPE = 'Group::DachverbandGremium::Mitglied'
+
   def up
-    Role.where(type: 'Group::DachverbandGremium::AktiverKursleiter')
-        .update_all(type: 'Group::DachverbandGremium::Mitglied')
+    # Migrate all active and past roles
+    Role.with_inactive.where(type: OLD_TYPE).update_all(type: NEW_TYPE)
+
+    # Update role type in PaperTrail version history so Verlauf remains viewable
+    versions_table = PaperTrail::Version.table_name
+    execute <<~SQL
+      UPDATE #{versions_table}
+      SET object = REPLACE(object, '#{OLD_TYPE}', '#{NEW_TYPE}')
+      WHERE item_type = 'Role' AND object LIKE '%#{OLD_TYPE}%'
+    SQL
+    execute <<~SQL
+      UPDATE #{versions_table}
+      SET object_changes = REPLACE(object_changes, '#{OLD_TYPE}', '#{NEW_TYPE}')
+      WHERE item_type = 'Role' AND object_changes LIKE '%#{OLD_TYPE}%'
+    SQL
+
+    # Remove from mailing list subscriptions and persisted person filters
+    RelatedRoleType.where(role_type: OLD_TYPE).delete_all
+
+    # Delete Group subscriptions that are now orphaned (no role types left)
+    execute <<~SQL
+      DELETE FROM subscriptions
+      WHERE id IN (
+        SELECT s.id
+        FROM subscriptions s
+        LEFT JOIN related_role_types rrt
+          ON rrt.relation_id = s.id AND rrt.relation_type = 'Subscription'
+        WHERE rrt.id IS NULL
+        AND s.subscriber_type = 'Group'
+      )
+    SQL
+
+    # Update persisted filter chains (PeopleFilter)
+    execute <<~SQL
+      UPDATE people_filters
+      SET filter_chain = REPLACE(filter_chain, '#{OLD_TYPE}', '#{NEW_TYPE}')
+      WHERE filter_chain LIKE '%#{OLD_TYPE}%'
+    SQL
+
+    # Update group self-registration role type
+    execute <<~SQL
+      UPDATE groups
+      SET self_registration_role_type = '#{NEW_TYPE}'
+      WHERE self_registration_role_type = '#{OLD_TYPE}'
+    SQL
+
+    # Update or remove pending person add requests for this role
+    execute <<~SQL
+      UPDATE person_add_requests
+      SET role_type = '#{NEW_TYPE}'
+      WHERE role_type = '#{OLD_TYPE}'
+    SQL
+
+    # Update invoice template items that reference this role type in their YAML parameters
+    execute <<~SQL
+      UPDATE period_invoice_template_items
+      SET dynamic_cost_parameters = REPLACE(dynamic_cost_parameters, '#{OLD_TYPE}', '#{NEW_TYPE}')
+      WHERE dynamic_cost_parameters LIKE '%#{OLD_TYPE}%'
+    SQL
+
+    # Update invoice items that reference this role type in their YAML parameters
+    execute <<~SQL
+      UPDATE invoice_items
+      SET dynamic_cost_parameters = REPLACE(dynamic_cost_parameters, '#{OLD_TYPE}', '#{NEW_TYPE}')
+      WHERE dynamic_cost_parameters LIKE '%#{OLD_TYPE}%'
+    SQL
   end
 
   def down

--- a/db/migrate/20260314000000_remove_aktiver_kursleiter_from_dachverband_gremium.rb
+++ b/db/migrate/20260314000000_remove_aktiver_kursleiter_from_dachverband_gremium.rb
@@ -1,0 +1,15 @@
+#  Copyright (c) 2026, Cevi.DB Steuergruppe. This file is part of
+#  hitobito_cevi and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cevi.
+
+class RemoveAktiverKursleiterFromDachverbandGremium < ActiveRecord::Migration[6.1]
+  def up
+    Role.where(type: 'Group::DachverbandGremium::AktiverKursleiter')
+        .update_all(type: 'Group::DachverbandGremium::Mitglied')
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The role "Aktive/-r Kursleiter/-in" is no longer needed at the Dachverband level. Existing roles are migrated to Mitglied (note: currently there are no such roles assigned but just as a safety measure), which has the same permissions. The role remains available on MitgliederorganisationGremium.

This implements https://github.com/cevi/hitobito_cevi/issues/45

Complete migration of AktiverKursleiter to clean up all role type references

The original migration only updated currently active roles. Per reviewer
feedback, extend it to also handle:
- Past/inactive roles (Role.with_inactive) so Verlauf pages don't error
- PaperTrail version history (object + object_changes) to keep audit logs viewable
- related_role_types for mailing list subscriptions and persisted person filters
- Orphaned Group subscriptions left after related_role_types cleanup
- PeopleFilter filter chains (YAML in filter_chain column)
- Group self-registration role type (self_registration_role_type column)
- Pending person add requests (person_add_requests.role_type)
- Invoice template items and invoice items (dynamic_cost_parameters YAML)