### PR TITLE
add controller test coverage and fix Devise 5.x sign_in compat

### DIFF
--- a/app/controllers/cevi/service_tokens_controller.rb
+++ b/app/controllers/cevi/service_tokens_controller.rb
@@ -9,7 +9,7 @@ module Cevi::ServiceTokensController
   extend ActiveSupport::Concern
 
   def permitted_attrs
-    permitted = self.class.permitted_attrs
+    permitted = self.class.permitted_attrs.dup
     permitted << :show_donors if can?(:show_donors, group)
     permitted
   end

--- a/spec/controllers/census_evaluation/dachverband_controller_spec.rb
+++ b/spec/controllers/census_evaluation/dachverband_controller_spec.rb
@@ -93,6 +93,25 @@ describe CensusEvaluation::DachverbandController do
         expect(CSV.parse(response.body, headers: true)).to have(3).rows
       end
     end
+
+    context 'with non-current census year' do
+      it 'does not assign group confirmation ratios' do
+        get :index, params: { id: ch.id, year: TESTYEAR + 2 }
+        expect(assigns(:groups)).to be_nil
+      end
+
+      it 'does not assign a total' do
+        get :index, params: { id: ch.id, year: TESTYEAR + 2 }
+        expect(assigns(:total)).to be_nil
+      end
+    end
+
+    context 'authorization' do
+      it 'denies access for unauthorized user' do
+        sign_in(people(:al_altst))
+        expect { get :index, params: { id: ch.id } }.to raise_error(CanCan::AccessDenied)
+      end
+    end
   end
 
 end

--- a/spec/controllers/census_evaluation/mitgliederorganisation_controller_spec.rb
+++ b/spec/controllers/census_evaluation/mitgliederorganisation_controller_spec.rb
@@ -57,4 +57,23 @@ describe CensusEvaluation::MitgliederorganisationController do
     end
   end
 
+  context 'authorization' do
+    it 'denies access for unauthorized user' do
+      sign_in(people(:al_altst))
+      expect { get :index, params: { id: zhshgl.id } }.to raise_error(CanCan::AccessDenied)
+    end
+  end
+
+  context 'with year parameter' do
+    it 'assigns counts for previous year' do
+      get :index, params: { id: zhshgl.id, year: TESTYEAR - 1 }
+      expect(assigns(:group_counts)).to be_empty
+    end
+
+    it 'assigns nil total for past year without census' do
+      get :index, params: { id: zhshgl.id, year: TESTYEAR - 1 }
+      expect(assigns(:total)).to be_nil
+    end
+  end
+
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -91,6 +91,26 @@ describe EventsController do
   end
 
 
+  context 'regular event (not course)' do
+    let(:group) { groups(:dachverband) }
+
+    before { sign_in(people(:bulei)) }
+
+    it 'creates regular event without setting application_contact' do
+      post :create, params: {
+        event: { group_ids: [group.id],
+                 name: 'Regular Event',
+                 dates_attributes: [{ label: 'foo', start_at_date: Date.today, finish_at_date: Date.today }],
+                 type: 'Event' },
+        group_id: group.id
+      }
+
+      event = assigns(:event)
+      expect(event).to be_persisted
+      expect(event).to be_a(Event)
+    end
+  end
+
   context '#index filters based on type' do
     require_relative '../support/fabrication.rb'
     before { sign_in(people(:bulei)) }

--- a/spec/controllers/member_counts_controller_spec.rb
+++ b/spec/controllers/member_counts_controller_spec.rb
@@ -164,6 +164,32 @@ describe MemberCountsController do
       is_expected.to redirect_to(census_group_group_path(group, year: TESTYEAR))
       expect(flash[:notice]).to be_present
     end
+
+    context 'as abteilungsleiter' do
+      it 'denies access' do
+        leiter = Fabricate(Group::Jungschar::Abteilungsleiter.name.to_sym, group: group).person
+        sign_in(leiter)
+        expect { delete :destroy, params: { group_id: group.id } }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
+
+  describe 'without current census' do
+    before { Census.destroy_all }
+
+    it 'raises RecordNotFound on edit' do
+      expect { get :edit, params: { group_id: group.id } }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises RecordNotFound on update' do
+      expect do
+        put :update, params: { group_id: group.id, member_count: {} }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises RecordNotFound on destroy' do
+      expect { delete :destroy, params: { group_id: group.id } }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 
   def assert_member_counts(count, person_f, person_m)

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -9,6 +9,31 @@ require 'spec_helper'
 
 describe PeopleController do
 
+  context 'cevi-specific permitted attributes' do
+    let(:person) { Fabricate(Group::Ortsgruppe::AdministratorCeviDB.name, group: groups(:stadtzh)).person }
+    let(:actor) do
+      Fabricate(Group::MitgliederorganisationGeschaeftsstelle::Geschaeftsleiter.name,
+                group: groups(:zhshgl_gs)).person
+    end
+
+    before { sign_in(actor) }
+
+    it 'allows updating nationality' do
+      put :update, params: { group_id: person.groups.first.id, id: person.id, person: { nationality: 'DE' } }
+      expect(person.reload.nationality).to eq('DE')
+    end
+
+    it 'allows updating j_s_number' do
+      put :update, params: { group_id: person.groups.first.id, id: person.id, person: { j_s_number: '12345' } }
+      expect(person.reload.j_s_number).to eq('12345')
+    end
+
+    it 'allows updating salutation' do
+      put :update, params: { group_id: person.groups.first.id, id: person.id, person: { salutation: 'formal' } }
+      expect(person.reload.salutation).to eq('formal')
+    end
+  end
+
   context 'old_data' do
     let(:person) { Fabricate(Group::Ortsgruppe::AdministratorCeviDB.name, group: groups(:stadtzh)).person }
 

--- a/spec/controllers/population_controller_spec.rb
+++ b/spec/controllers/population_controller_spec.rb
@@ -63,4 +63,26 @@ describe PopulationController do
 
     it { is_expected.not_to include aranda }
   end
+
+  describe 'authorization' do
+    it 'denies access for user without show_population permission' do
+      unauthorized = Fabricate(Group::Froeschli::Teilnehmer.name.to_sym, group: froeschli).person
+      sign_in(unauthorized)
+      expect { get :index, params: { id: jungschar.id } }.to raise_error(CanCan::AccessDenied)
+    end
+  end
+
+  describe 'people_data_complete' do
+    context 'when all people have gender' do
+      before do
+        # Give all people in the population a gender
+        Person.update_all(gender: 'w')
+        get :index, params: { id: jungschar.id }
+      end
+
+      subject { assigns(:people_data_complete) }
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end

--- a/spec/controllers/service_tokens_controller_spec.rb
+++ b/spec/controllers/service_tokens_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, CEVI Schweiz. This file is part of
+#  hitobito_cevi and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cevi.
+
+require 'spec_helper'
+
+describe ServiceTokensController do
+  let(:group) { groups(:dachverband) }
+  let(:gs_group) { groups(:dachverband_gs) }
+
+  context 'with show_donors permission (financials role)' do
+    let(:person) do
+      Fabricate(Group::DachverbandGeschaeftsstelle::Finanzverantwortlicher.name.to_sym,
+                group: gs_group).person
+    end
+
+    before { sign_in(person) }
+
+    it 'includes show_donors in permitted params and saves it' do
+      token = Fabricate(:service_token, layer: group)
+      patch :update, params: {
+        group_id: group.id,
+        id: token.id,
+        service_token: { show_donors: true }
+      }
+      expect(token.reload.show_donors).to be true
+    end
+
+    it 'can clear show_donors' do
+      token = Fabricate(:service_token, layer: group, show_donors: true)
+      patch :update, params: {
+        group_id: group.id,
+        id: token.id,
+        service_token: { show_donors: false }
+      }
+      expect(token.reload.show_donors).to be false
+    end
+  end
+
+  context 'without show_donors permission (finance but not financials role)' do
+    let(:person) do
+      Fabricate(Group::DachverbandGeschaeftsstelle::Geschaeftsleiter.name.to_sym,
+                group: gs_group).person
+    end
+
+    before { sign_in(person) }
+
+    it 'ignores show_donors param and leaves it false' do
+      token = Fabricate(:service_token, layer: group)
+      patch :update, params: {
+        group_id: group.id,
+        id: token.id,
+        service_token: { show_donors: true }
+      }
+      expect(token.reload.show_donors).to be false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,20 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
 require File.join(ENV["APP_ROOT"], "spec", "spec_helper.rb")
 
+# Fix sign_in compatibility with Devise 5.x (which removed the deprecated positional
+# scope arg). Hitobito core's spec_helper prepends an anonymous module that calls
+# super(resource, nil, scope: scope), which breaks Devise 5.x. We find that anonymous
+# module and redefine its method to use the new keyword-only signature.
+hitobito_prepend = Devise::Test::ControllerHelpers.ancestors.find do |mod|
+  !mod.name && mod.instance_methods(false).include?(:sign_in)
+end
+hitobito_prepend&.class_eval do
+  def sign_in(resource, scope: nil, confirm: true)
+    resource.confirm if confirm
+    super(resource, scope: scope)
+  end
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[HitobitoCevi::Wagon.root.join("spec/support/**/*.rb")].sort.each { |f| require f }


### PR DESCRIPTION
Fix a mutation bug in Cevi::ServiceTokensController#permitted_attrs where self.class.permitted_attrs was mutated directly instead of duplicated first, permanently adding :show_donors to the shared class-level array after the first request by a user with the financials permission.

Fix sign_in compatibility with Devise 5.x in the wagon's spec_helper: the hitobito core spec_helper prepends an anonymous module that calls super(resource, nil, scope: scope), which broke when Devise 5.0.2 removed the deprecated positional scope argument. Patched by redefining the method on that anonymous module after core's spec_helper loads.

Add controller specs to improve coverage:
- spec/controllers/service_tokens_controller_spec.rb (new): tests that :show_donors is included in permitted params only for users with the financials permission
- MemberCountsController: delete access denial for Abteilungsleiter; RecordNotFound on edit/update/destroy when no current census exists
- CensusEvaluation::DachverbandController: non-current census year (no group confirmation ratios, nil total); authorization denial
- CensusEvaluation::MitgliederorganisationController: authorization denial; year parameter with past year returns empty counts and nil total
- PopulationController: authorization denial; people_data_complete=true when all people have gender set
- PeopleController: cevi-specific permitted attributes (nationality, j_s_number, salutation) can be saved
- EventsController: regular event creation (non-course) where application_contact_id is not used

Fixes: https://github.com/cevi/hitobito_cevi/issues/250